### PR TITLE
BUGFIX python3.6 stylers fixed to return integer color tuple

### DIFF
--- a/stylers/default.py
+++ b/stylers/default.py
@@ -13,4 +13,4 @@ class DotNodeStyler:
         r = 0.8
         g = 0.8 - float(call.sum_self_time) / (self.max_self_time) * 0.8
         b = 0.8 - float(call.call_count - 1) / float(self.max_call_count) * 0.8
-        return (255 * r, 255 * g ,255 * b)
+        return tuple(map(round, (255 * r, 255 * g, 255 * b)))


### PR DESCRIPTION
In python3.6 we have such error:

Traceback (most recent call last):
  File "/usr/sbin/cg2dot", line 50, in <module>
    print(DotBuilder().get_dot(merged_tree, DotNodeStyler))
  File "/usr/lib/python3.6/site-packages/dot.py", line 31, in get_dot
    color = "#%02x%02x%02x" % node_styler.colorize(stack[-1])
TypeError: %x format: an integer is required, not float